### PR TITLE
feat: modernize frontend layout

### DIFF
--- a/class/db_pdo.php
+++ b/class/db_pdo.php
@@ -370,13 +370,12 @@ class db_pdo {
      * @param string $date
      */
     function footerNewEntryGenerator($marque, $modele, $serialNumber, $date) {
-        if (!isset($marque) OR !isset($modele) OR !isset($serialNumber)) {
-            echo "<footer>Il semblent y a voir des erreur</footer>";
+        if (!isset($marque) || !isset($modele) || !isset($serialNumber)) {
+            return "<div class='alert alert-error'>Il semblent y avoir des erreur</div>";
         } else {
-            echo "<footer> L'appareil au numéro de série " . $serialNumber .
-            " de marque " . $marque . " dont le modele est " .
-            $modele . " est retirer du service à date du " . $date . "</footer>";
-            ;
+            return "<div class='alert alert-success'> L'appareil au numéro de série " . $serialNumber .
+                " de marque " . $marque . " dont le modele est " .
+                $modele . " est retirer du service à date du " . $date . "</div>";
         }
     }
 

--- a/class/utilitary_class.php
+++ b/class/utilitary_class.php
@@ -20,23 +20,24 @@ class utilitary_class {
     }
     
     function header_generator_automatic() {
+        $current = basename($_SERVER['PHP_SELF']);
+        $navItems = [
+            'index.php' => 'Accueil',
+            'list_agent.php' => 'Agents',
+            'modify_entry.php' => 'Modifier',
+            'pdf_historic.php' => 'Historique PDF'
+        ];
 
-        echo "<header><center><h1>Retrait de Service</h1><br>";
-        $arrayDir = scandir("./");
+        echo "<header class='main-header'><div class='container'>";
+        echo "<h1 class='site-title'>Retrait de Service</h1>";
+        echo "<nav><ul class='nav'>";
 
-        foreach ($arrayDir as $document) {
-            if ($document != "." AND $document != ".." AND $document != "class" AND $document != "historic_agent.php"
-                    AND $document != "test.php" AND $document != "modify_entry.php" AND $document != "style"
-                    AND $document != "latex" AND $document != "Doxyfile") {
-                $arrayDocument = explode(".php", $document);
-                if ($document != "index.php") {
-                    echo "<a href='" . $document . "'>" . $arrayDocument[0] . "</a> ";
-                } else {
-                    echo "<a href='" . $document . "'>retrait_materielle</a>  ";
-                }
-            }
+        foreach ($navItems as $file => $label) {
+            $active = $current === $file ? " class='active'" : '';
+            echo "<li><a href='" . $file . "'" . $active . ">" . $label . "</a></li>";
         }
-        echo "</center></header>";
+
+        echo "</ul></nav></div></header>";
     }
     /**
      * Vérificateur via division

--- a/historic_agent.php
+++ b/historic_agent.php
@@ -1,21 +1,20 @@
-<head>
-        <meta charset="UTF-8">
-        <title>Historique</title>
-         <link rel="stylesheet" href="style/basic.css"> 
-</head>
 <?php
 require_once 'class/utilitary_class.php';
-$gestion_utilitary = new utilitary_class();
-$gestion_utilitary->header_generator_automatic();
-
 require_once 'class/membre_class.php';
 
+$gestion_utilitary = new utilitary_class();
 $gestion_membre = new membre_class();
-$urlEncode = htmlspecialchars($_SERVER["REQUEST_URI"]);
 
+$urlEncode = htmlspecialchars($_SERVER["REQUEST_URI"]);
 $arrayName = $gestion_utilitary->decodeDefineVariable($urlEncode, 2);
 
+$title = 'Historique';
+require 'partials/header.php';
+
+echo "<div class='card'>";
 $gestion_membre->find_historic($arrayName[0], $arrayName[1]);
+echo "</div>";
 
+echo "<br><a href='list_agent.php' class='btn-link'>Retour</a>";
 
-echo "<br><a href='list_agent.php'>Retour</a>";
+require 'partials/footer.php';

--- a/index.php
+++ b/index.php
@@ -1,58 +1,50 @@
-<!DOCTYPE html>
 <?php
-    try {
-            date_default_timezone_set("Europe/Paris");
-            include_once 'class/db_pdo.php';
-            include_once 'class/utilitary_class.php';
-            $gestion_pdo = new db_pdo();
-            $gestion_utilitary = new utilitary_class();
-            ?>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title>Nouvelle Entrée</title>
-         <link rel="stylesheet" href="style/basic.css"> 
-    </head>
-    
-   <?php
-    $gestion_utilitary->header_generator_automatic();
-   ?>
-    
-    <body>
-        <form method="POST">
-            Marque:
-            <input type="text" name="marque" placeholder="Nom de Marque"><br>
-            Modele:
-            <input type="text" name="modele" placeholder="Nom de Modele"><br>
-            Numéros de Serie: 
-            <input name="serialNumber" type="text" required><br>
-            Agent:
-            <?php
-                $gestion_pdo->selectFormAgent();
-            ?>  
-            <input type="submit"><br>
-       
-        
-        
-        <?php
-            
-            $nameAgentEncode = htmlspecialchars($_POST["agentSelect"]);
-            $nameArrayDecode = explode("placeholder", $nameAgentEncode);
-            $nomAgent = $nameArrayDecode[0];
-            $prenomAgent = $nameArrayDecode[1];
+require_once 'class/db_pdo.php';
 
-            $idMarque = $gestion_pdo->marqueExist(htmlspecialchars($_POST["marque"]));
-            $idModele = $gestion_pdo->modeleExist(htmlspecialchars($_POST["modele"]), $idMarque);
-            $idAgent = $gestion_pdo->gestion_agent(htmlspecialchars($prenomAgent), htmlspecialchars($nomAgent));
-            $today = date("Y-m-d H:i:s");
-            $gestion_pdo->new_retrait_appareil([$idMarque, $idModele, htmlspecialchars($_POST["serialNumber"]), $idAgent, $today], "add");
+date_default_timezone_set("Europe/Paris");
+$gestion_pdo = new db_pdo();
+$successMessage = '';
 
-            $gestion_pdo->footerNewEntryGenerator(htmlspecialchars($_POST["marque"]), htmlspecialchars($_POST["modele"]), htmlspecialchars($_POST["serialNumber"]), $today);
-        } catch (Exception $ex) {
-            echo "Il semblent y avoir eux une erreur  </form>";
-        }
-        ?>
-    </body>
-    
-    
-</html>
+if (
+    $_SERVER['REQUEST_METHOD'] === 'POST' &&
+    !empty($_POST['marque']) &&
+    !empty($_POST['modele']) &&
+    !empty($_POST['serialNumber'])
+) {
+    $nameAgentEncode = htmlspecialchars($_POST["agentSelect"]);
+    $nameArrayDecode = explode("placeholder", $nameAgentEncode);
+    $nomAgent = $nameArrayDecode[0];
+    $prenomAgent = $nameArrayDecode[1];
+
+    $idMarque = $gestion_pdo->marqueExist(htmlspecialchars($_POST["marque"]));
+    $idModele = $gestion_pdo->modeleExist(htmlspecialchars($_POST["modele"]), $idMarque);
+    $idAgent = $gestion_pdo->gestion_agent(htmlspecialchars($prenomAgent), htmlspecialchars($nomAgent));
+    $today = date("Y-m-d H:i:s");
+    $gestion_pdo->new_retrait_appareil([$idMarque, $idModele, htmlspecialchars($_POST["serialNumber"]), $idAgent, $today], "add");
+    $successMessage = $gestion_pdo->footerNewEntryGenerator(
+        htmlspecialchars($_POST["marque"]),
+        htmlspecialchars($_POST["modele"]),
+        htmlspecialchars($_POST["serialNumber"]),
+        $today
+    );
+}
+
+$title = 'Nouvelle Entrée';
+require 'partials/header.php';
+?>
+<form method="POST" class="form-entry card">
+    <label for="marque">Marque:</label>
+    <input type="text" id="marque" name="marque" placeholder="Nom de Marque"><br>
+    <label for="modele">Modele:</label>
+    <input type="text" id="modele" name="modele" placeholder="Nom de Modele"><br>
+    <label for="serialNumber">Numéros de Serie:</label>
+    <input id="serialNumber" name="serialNumber" type="text" required><br>
+    <label for="agentSelect">Agent:</label>
+    <?php $gestion_pdo->selectFormAgent(); ?><br>
+    <button type="submit">Enregistrer</button>
+</form>
+<?php
+if ($successMessage) {
+    echo $successMessage;
+}
+require 'partials/footer.php';

--- a/list_agent.php
+++ b/list_agent.php
@@ -1,43 +1,39 @@
-<head>
-        <meta charset="UTF-8">
-        <title>Liste des Agents</title>
-         <link rel="stylesheet" href="style/basic.css"> 
-</head>
 <?php
-include_once 'class/utilitary_class.php';
-include_once 'class/membre_class.php';
+require_once 'class/membre_class.php';
 
-$gestion_utilitary = new utilitary_class();
 $gestion_membre = new membre_class();
-
-$gestion_utilitary->header_generator_automatic();
-
 $listAgent = $gestion_membre->member_find();
-$numberAgent =  count($listAgent[0]);
-echo "<ul>";
-for($i=0; $i <= ($numberAgent-1); $i++) {
-    echo "<li><a href='historic_agent.php?value=". urlencode($listAgent[0][$i]."placeholder".$listAgent[1][$i])."'>".$listAgent[0][$i]." ".$listAgent[1][$i]."</a><br>";
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $gestion_membre->agentExist([
+        htmlspecialchars($_POST["nomAgent"]),
+        htmlspecialchars($_POST["prenomAgent"]),
+        $_POST["roleAgent"]
+    ]);
 }
 
+$title = 'Liste des Agents';
+require 'partials/header.php';
 ?>
-</li>
+<ul class="agent-list card">
+<?php
+$numberAgent = count($listAgent[0]);
+for ($i = 0; $i <= ($numberAgent - 1); $i++) {
+    echo "<li><a href='historic_agent.php?value=" . urlencode($listAgent[0][$i] . "placeholder" . $listAgent[1][$i]) . "'>" . $listAgent[0][$i] . " " . $listAgent[1][$i] . "</a></li>";
+}
+?>
 </ul>
 
-<form method="POST" name="formNewAgent">
-    <b>Vous n'y apparaisser pas ?(*)</b><br>
-    Inscriver vous!<br>
-    Prenom:
-    <input type="text" name="prenomAgent" placeholder="prenom"><br>
-    Nom de famille:
-    <input type="text" name="nomAgent" placeholder="nom"><br>
-    Role:
-<?php
-    $gestion_membre->selectRoleAgent();
-?>
-    <input type="submit">
-<br><i>(*)Si vous souhaitez rentrer un appareil, il faut vous inscrire ici. </form>
-<?php
-$gestion_membre->agentExist([htmlspecialchars($_POST["nomAgent"]), htmlspecialchars($_POST["prenomAgent"]), $_POST["roleAgent"]]);
-
-
-
+<form method="POST" name="formNewAgent" class="form-agent mt-3 card">
+    <p><strong>Vous n'y apparaissez pas ?(*)</strong></p>
+    <p>Inscrivez-vous!</p>
+    <label for="prenomAgent">Prenom:</label>
+    <input type="text" id="prenomAgent" name="prenomAgent" placeholder="prenom"><br>
+    <label for="nomAgent">Nom de famille:</label>
+    <input type="text" id="nomAgent" name="nomAgent" placeholder="nom"><br>
+    <label for="roleAgent">Role:</label>
+    <?php $gestion_membre->selectRoleAgent(); ?><br>
+    <button type="submit">Valider</button>
+    <p><i>(*)Si vous souhaitez rentrer un appareil, il faut vous inscrire ici.</i></p>
+</form>
+<?php require 'partials/footer.php';

--- a/modify_entry.php
+++ b/modify_entry.php
@@ -1,42 +1,46 @@
-<head>
-        <meta charset="UTF-8">
-        <title>Modification de l'entrée</title>
-         <link rel="stylesheet" href="style/basic.css"> 
-</head>
 <?php
-require_once 'class/utilitary_class.php';
-$gestion_utilitary = new utilitary_class();
-$gestion_utilitary->header_generator_automatic();
-echo "<form method='Post'>";
 require_once 'class/membre_class.php';
 require_once 'class/db_pdo.php';
+require_once 'class/utilitary_class.php';
 
 $gestion_membre = new membre_class();
 $gestion_pdo = new db_pdo();
+$gestion_utilitary = new utilitary_class();
 
 $urlEncode = urldecode(htmlspecialchars($_SERVER["REQUEST_URI"]));
 $arrayUrl = explode("?value=", $urlEncode);
-
 $arrayValue = explode("/d8dz8zdpp@", $arrayUrl[1]);
-echo "Marque: <input type='text' value='$arrayValue[0]' name='nameMarque'><br>";
-echo "Modele: <input type='text' value='$arrayValue[1]' name='nameModele'><br>";
-echo "Numéro de Serie: <input type='text' value='$arrayValue[2]' name='serialNumber'><br>";
-echo "<input type='submit'>";
 
-if (empty(trim($_POST["nameMarque"])) || empty(trim($_POST["nameModele"])) || empty(trim($_POST["serialNumber"]))) {
-    echo "<footer>Il semblent y a voir des erreur</footer></form>";
-} else {
-    echo "</form>";
+if (
+    $_SERVER['REQUEST_METHOD'] === 'POST' &&
+    !empty(trim($_POST["nameMarque"])) &&
+    !empty(trim($_POST["nameModele"])) &&
+    !empty(trim($_POST["serialNumber"]))
+) {
     $nomMarque = htmlspecialchars($_POST["nameMarque"]);
     $nomModele = htmlspecialchars($_POST["nameModele"]);
     $serialNumber = htmlspecialchars($_POST["serialNumber"]);
 
     $idAgent = $gestion_pdo->findUserbySerialNumberAndDate($arrayValue[2], $arrayValue[3]);
     $gestion_pdo->removeEntrybySerialNumberAndDate($arrayValue[2], $arrayValue[3], $idAgent);
-    $idMarque = $gestion_pdo->marqueExist(htmlspecialchars($nomMarque));
-    $idModele = $gestion_pdo->modeleExist(htmlspecialchars($nomModele), $idMarque);
+    $idMarque = $gestion_pdo->marqueExist($nomMarque);
+    $idModele = $gestion_pdo->modeleExist($nomModele, $idMarque);
     $gestion_pdo->new_retrait_appareil([$idMarque, $idModele, $serialNumber, $idAgent, $arrayValue[3]], "modify");
 
-    header("Location: modify_entry.php?value=" . urlencode($nomMarque . "/d8dz8zdpp@" . $nomModele .
-                    "/d8dz8zdpp@" . $serialNumber . "/d8dz8zdpp@" . $arrayValue[3]) . ".php");
+    header("Location: modify_entry.php?value=" . urlencode($nomMarque . "/d8dz8zdpp@" . $nomModele . "/d8dz8zdpp@" . $serialNumber . "/d8dz8zdpp@" . $arrayValue[3]));
+    exit;
 }
+
+$title = 'Modification de l\'entrée';
+require 'partials/header.php';
+?>
+<form method="POST" class="form-entry card">
+    <label for="nameMarque">Marque:</label>
+    <input type="text" id="nameMarque" value="<?php echo htmlspecialchars($arrayValue[0]); ?>" name="nameMarque"><br>
+    <label for="nameModele">Modele:</label>
+    <input type="text" id="nameModele" value="<?php echo htmlspecialchars($arrayValue[1]); ?>" name="nameModele"><br>
+    <label for="serialNumber">Numéro de Serie:</label>
+    <input type="text" id="serialNumber" value="<?php echo htmlspecialchars($arrayValue[2]); ?>" name="serialNumber"><br>
+    <button type="submit">Enregistrer</button>
+</form>
+<?php require 'partials/footer.php';

--- a/partials/footer.php
+++ b/partials/footer.php
@@ -1,0 +1,6 @@
+</main>
+<footer class="main-footer text-center">
+    <small>&copy; <?php echo date('Y'); ?> Retrait de Service</small>
+</footer>
+</body>
+</html>

--- a/partials/header.php
+++ b/partials/header.php
@@ -1,0 +1,15 @@
+<?php
+if (!isset($gestion_utilitary)) {
+    require_once __DIR__ . '/../class/utilitary_class.php';
+    $gestion_utilitary = new utilitary_class();
+}
+?><!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title><?php echo htmlspecialchars($title ?? 'Retrait de Service'); ?></title>
+    <link rel="stylesheet" href="style/basic.css">
+</head>
+<body>
+<?php $gestion_utilitary->header_generator_automatic(); ?>
+<main class="container">

--- a/pdf_historic.php
+++ b/pdf_historic.php
@@ -1,23 +1,19 @@
-<html>
-    <!DOCTYPE html>
-    <head>
-        <meta charset="UTF-8">
-        <title>Historique en PDF</title>
-         <link rel="stylesheet" href="style/basic.css"> 
-    </head>
-
 <?php
-    require_once 'class/membre_class.php';
-    require_once 'class/utilitary_class.php';
-    
-    $gestion_membre = new membre_class();
-    $gestion_utilitary = new utilitary_class();
-    
-try {
-    $gestion_utilitary->header_generator_automatic();
-    $gestion_membre->formAndExecutePdfHistoricUser();
+require_once 'class/membre_class.php';
+require_once 'class/utilitary_class.php';
 
-} catch (Exception) {
+$gestion_membre = new membre_class();
+$gestion_utilitary = new utilitary_class();
+
+$title = 'Historique en PDF';
+require 'partials/header.php';
+
+echo "<div class='card'>";
+try {
+    $gestion_membre->formAndExecutePdfHistoricUser();
+} catch (Exception $e) {
     echo "Il semblent y avoir un soucis!";
 }
+echo "</div>";
 
+require 'partials/footer.php';

--- a/style/basic.css
+++ b/style/basic.css
@@ -292,3 +292,83 @@ form {
 
 
 
+
+/* ===========================
+   Header & Navigation
+   =========================== */
+.main-header {
+  background-color: #2a76d2;
+  color: #fff;
+  margin-bottom: 2rem;
+}
+
+.main-header .container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.nav {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+}
+
+.nav a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.nav a.active {
+  font-weight: 700;
+  text-decoration: underline;
+}
+
+.nav a:hover {
+  text-decoration: underline;
+}
+
+.main-footer {
+  margin-top: 2rem;
+  padding: 1rem 0;
+  background-color: #f0f0f0;
+}
+
+.card {
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.agent-list {
+  list-style: none;
+  padding: 0;
+}
+
+.agent-list li + li {
+  margin-top: 0.5rem;
+}
+
+.agent-list a {
+  color: #2a76d2;
+  text-decoration: none;
+}
+
+.agent-list a:hover {
+  text-decoration: underline;
+}
+
+.btn-link {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  background-color: #2a76d2;
+  color: #fff;
+  border-radius: 4px;
+  text-decoration: none;
+}
+
+.btn-link:hover {
+  background-color: #1f5bb5;
+}


### PR DESCRIPTION
## Summary
- replace directory scan navigation with explicit links and active state
- introduce card and button styles for unified UI
- wrap forms and lists with card containers

## Testing
- `php -l index.php list_agent.php historic_agent.php modify_entry.php pdf_historic.php class/utilitary_class.php`
- `php -l partials/header.php partials/footer.php`


------
https://chatgpt.com/codex/tasks/task_e_689e53bf7fc08333959373d6a62fee22